### PR TITLE
Fix Malformed Build Flag and Broken 3rd Party Dependency

### DIFF
--- a/codec/ext_dep_test.go
+++ b/codec/ext_dep_test.go
@@ -1,4 +1,4 @@
-// //+build ignore
+//+build ignore
 
 // Copyright (c) 2012, 2013 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a BSD-style license found in the LICENSE file.

--- a/codec/ext_dep_test.go
+++ b/codec/ext_dep_test.go
@@ -12,15 +12,15 @@ package codec
 //   - Uncomment first line in this file (put // // in front of it)
 //   - Get those packages:
 //       go get github.com/vmihailenco/msgpack
-//       go get labix.org/v2/mgo/bson
+//       go get gopkg.in/mgo.v2/bson
 //   - Run:
 //       go test -bi -bench=.
 
 import (
 	"testing"
 
+	"gopkg.in/mgo.v2/bson"
 	vmsgpack "gopkg.in/vmihailenco/msgpack.v2"
-	"labix.org/v2/mgo/bson"
 )
 
 func init() {


### PR DESCRIPTION
Fixing test files which don't build due to to a broken 3rd party dependency link as well as a malformed build flag. 

This causes an issue with `go get -t` as well as the updated `go get` and `go mod` commands with modules enabled (go1.11beta2).

_This is critical because it's a downstream dependency of consul's API which can no longer be retrieved using `go get` with go modules support, or `go get -t` (include test dependencies) in current and legacy Go versions._