### PR TITLE
Do not attempt to set unsettable types

### DIFF
--- a/codec/decode.go
+++ b/codec/decode.go
@@ -527,7 +527,7 @@ func (f *decFnInfo) kMap(rv reflect.Value) {
 			}
 		}
 		rvv := rv.MapIndex(rvk)
-		if !rvv.IsValid() {
+		if !rvv.IsValid() || !rvv.CanSet() {
 			rvv = reflect.New(vtype).Elem()
 		}
 


### PR DESCRIPTION
Previously the following would fail:

```go
package main

import (
   "github.com/hashicorp/go-msgpack/codec"
)

type WithMap struct {
   Map map[string]string
}

func main() {
   x := WithMap{Map: map[string]string{"foo": "bar"}}
   y := WithMap{Map: map[string]string{"foo": "baz"}}

   var buf []byte
   hnd := codec.MsgpackHandle{}
   enc := codec.NewEncoderBytes(&buf, &hnd)

   err := enc.Encode(x)
   if err != nil {
      panic(err)
   }

   dec := codec.NewDecoderBytes(buf, &hnd)
   err = dec.Decode(&y)
   if err != nil {
      panic(err)
   }
}
```

This PR fixes that.