### PR TITLE
codec: do not dereference pointers/interfaces for omitempty support.

### DIFF
--- a/codec/codecs_test.go
+++ b/codec/codecs_test.go
@@ -698,6 +698,34 @@ func testCodecMiscOne(t *testing.T, h Handle) {
 		var ya = ystruct{}
 		testUnmarshalErr(&ya, []byte{0x91, 0x90}, h, t, "ya")
 	}
+
+	// test omitempty and nested structs
+	type omitN struct {
+		A *bool
+	}
+	type omitS struct {
+		N *omitN `codec:",omitempty"`
+	}
+	trueV, falseV := true, false
+	var omits = []omitS{
+		{},
+		{&omitN{A: &trueV}},
+		{&omitN{A: &falseV}},
+	}
+	for _, omitA := range omits {
+		bs, err := testMarshalErr(omitA, h, t, "omitA")
+		if err != nil {
+			logT(t, "error marshalling omitA: %v", err)
+			t.FailNow()
+		}
+		var omit2 omitS
+		err = testUnmarshalErr(&omit2, bs, h, t, "omit2")
+		if err != nil {
+			logT(t, "error unmarshalling omit2: %v", err)
+			t.FailNow()
+		}
+		checkEqualT(t, omitA, omit2, "omitA=omit2")
+	}
 }
 
 func testCodecEmbeddedPointer(t *testing.T, h Handle) {

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -45,6 +45,13 @@ const (
 	// for debugging, set this to false, to catch panic traces.
 	// Note that this will always cause rpc tests to fail, since they need io.EOF sent via panic.
 	recoverPanicToErr = true
+
+	// if checkStructForEmptyValue, check structs fields to see if an empty value.
+	// This could be an expensive call, so possibly disable it.
+	checkStructForEmptyValue = false
+
+	// if derefForIsEmptyValue, deref pointers and interfaces when checking isEmptyValue
+	derefForIsEmptyValue = false
 )
 
 type charEncoding uint8


### PR DESCRIPTION
This backports empty value checking changes from https://github.com/ugorji/go that are found in 006e1534301cb75b848ee452ab5d3ba8c6a70784 and 66dd47f2e86ef2197b1efe113185bed93ebd5e28 .

Without this change, omitempty treats pointer to empty values as empty (e.g. if a field is `*bool` and value is a reference to false), and treating a struct pointer is empty if all elements of struct as empty (e.g. if a field is of type `*struct { A string }`, then `nil` and `&{""}` values would be treated as empty and omitted).

This fixes the issue to be inline with json/encoding - where pointer is treated as empty and omitted only if it's a nil pointer.

Original Comment description from 66dd47f2e86ef2197b1efe113185bed93ebd5e28 :

> This is in line with the standard set by encoding/json
> i.e. if omitempty=true, pointers/interfaces are omitted iff nil.
>
> Previously, I "mistakenly" thought that
> encoding/json dereferenced pointers/interfaces when checking if empty.
>
> Fixes #67

I've also added a test for the case that wasn't in original repo.  The style of repo tests is a bit odd, and I conformed with it rather than establish a new test style.