### PR TITLE
fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ugorji/go
+module github.com/hashicorp/go-msgpack
 
 go 1.13
 


### PR DESCRIPTION
the contents of go.mod were `ugorji/go`, instead of `hashicorp/go-msgpack`

this caused errors when using this module:
```
go: github.com/hashicorp/go-msgpack@v0.0.0-20190927083313-23165f7bc3c2: parsing go.mod: unexpected module path "github.com/ugorji/go"
```

this change is consistent with the [go.mod contents](https://github.com/hashicorp/go-msgpack/blob/ad60660ecf9c5a1eae0ca32182ed72bab5807961/go.mod) on the master branch
of hashicorp/go-msgpack