### PR TITLE
Close conn on WriteResponse errors and add Nomad to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance
+* @hashicorp/team-ip-compliance @hashicorp/nomad-eng
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting

--- a/codec/rpc.go
+++ b/codec/rpc.go
@@ -162,7 +162,13 @@ func (c *goRpcCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 }
 
 func (c *goRpcCodec) WriteResponse(r *rpc.Response, body interface{}) error {
-	return c.write(r, body, true)
+	err := c.write(r, body, true)
+	if err != nil {
+		// If error occurred writing a response, close the underlying connection.
+		// See hashicorp/net-rpc-msgpackrpc#15
+		c.Close()
+	}
+	return err
 }
 
 func (c *goRpcCodec) ReadResponseHeader(r *rpc.Response) error {


### PR DESCRIPTION
Port the fix from hashicorp/net-rpc-msgpackrpc#15

**For consistency only.** To the best of my knowledge no HashiCorp tools use this code. They only use the serialization code from this package and all use hashicorp/net-rpc-msgpackrpc for RPC.

Also add @hashicorp/nomad-eng to CODEOWNERS as in https://github.com/hashicorp/go-sockaddr/pull/75

Team will also need repo write access.