### PR TITLE
IND-2428 test.yml updated with unit test coverage and linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,8 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Checkout Code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Determine Go version
         id: get-go-version
         run: |
@@ -21,20 +22,38 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-go-version]
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - name: Chekout Code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - run: 'exit $(( $(gofmt -s -l . | wc -l) != 0 ))'
+      - name: Check formatting
+        run: 'exit $(( $(gofmt -s -l . | wc -l) != 0 ))'
 
   test:
     name: codec test
     runs-on: ubuntu-latest
     needs: [get-go-version]
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - name: Checkout Code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
       - run: go test -v ./codec
       - run: go test -tags codecgen.exec -v ./codec
+      - name: Generate coverage report
+        run: go test -v -coverprofile=coverage.out ./...
+      - name: Upload coverage report
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          path: coverage.out
+          name: Coverage-report
+      - name: Display coverage report
+        run: go tool cover -func=coverage.out
+      - name: Build Go
+        run: go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+ enable:
+   - errcheck
+   - gosimple
+ disable:
+   - unused
+   - ineffassign
+   - staticcheck
+output_format: colored-line-number

--- a/codec/bench/bench_test.go
+++ b/codec/bench/bench_test.go
@@ -172,7 +172,6 @@ func doBenchCheck(name string, encfn benchEncFn, decfn benchDecFn) {
 	} else {
 		logT(nil, "\t%10s: len: %d bytes,\t encode: %v,\t decode: %v", name, encLen, encDur, decDur)
 	}
-	return
 }
 
 func fnBenchmarkEncode(b *testing.B, encName string, ts interface{}, encfn benchEncFn) {

--- a/codec/bench/shared_test.go
+++ b/codec/bench/shared_test.go
@@ -45,7 +45,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 	"testing"
@@ -132,7 +131,7 @@ var (
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard) // don't allow things log to standard out/err
+	log.SetOutput(io.Discard) // don't allow things log to standard out/err
 	testHEDs = make([]testHED, 0, 32)
 	testHandles = append(testHandles,
 		// testNoopH,

--- a/codec/gen-internal.go
+++ b/codec/gen-internal.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"strings"
 	"sync"
 	"text/template"
@@ -258,7 +257,7 @@ func genInternalGoFile(r io.Reader, w io.Writer) (err error) {
 
 	t := template.New("").Funcs(genInternalTmplFuncs)
 
-	tmplstr, err := ioutil.ReadAll(r)
+	tmplstr, err := io.ReadAll(r)
 	if err != nil {
 		return
 	}
@@ -275,10 +274,15 @@ func genInternalGoFile(r io.Reader, w io.Writer) (err error) {
 
 	bout, err := format.Source(out.Bytes())
 	if err != nil {
-		w.Write(out.Bytes()) // write out if error, so we can still see.
+		if _, err := w.Write(out.Bytes()); err != nil {
+			return err
+		}
+		// write out if error, so we can still see.
 		// w.Write(bout) // write out if error, as much as possible, so we can still see.
 		return
 	}
-	w.Write(bout)
+	if _, err := w.Write(bout); err != nil {
+		return err
+	}
 	return
 }

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -741,7 +741,7 @@ func (x *BasicHandle) fn(rt reflect.Type, checkFastpath, checkCodecSelfer bool) 
 					xfnf2 := fastpathAV[idx].decfn
 					fn.fd = func(d *Decoder, xf *codecFnInfo, xrv reflect.Value) {
 						if xrv.Kind() == reflect.Ptr {
-							xfnf2(d, xf, xrv.Convert(reflect.PtrTo(xrt)))
+							xfnf2(d, xf, xrv.Convert(reflect.PointerTo(xrt)))
 						} else {
 							xfnf2(d, xf, xrv.Convert(xrt))
 						}
@@ -1917,7 +1917,7 @@ func rgetResolveSFI(rt reflect.Type, x []structFieldInfo, pv *typeInfoLoadArray)
 }
 
 func implIntf(rt, iTyp reflect.Type) (base bool, indir bool) {
-	return rt.Implements(iTyp), reflect.PtrTo(rt).Implements(iTyp)
+	return rt.Implements(iTyp), reflect.PointerTo(rt).Implements(iTyp)
 }
 
 // isEmptyStruct is only called from isEmptyValue, and checks if a struct is empty:

--- a/codec/shared_test.go
+++ b/codec/shared_test.go
@@ -45,7 +45,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"sync"
 	"testing"
@@ -132,7 +131,7 @@ var (
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard) // don't allow things log to standard out/err
+	log.SetOutput(io.Discard) // don't allow things log to standard out/err
 	testHEDs = make([]testHED, 0, 32)
 	testHandles = append(testHandles,
 		// testNoopH,


### PR DESCRIPTION
I have added unit test coverage and linting to the test.yml workflow.

The unit test coverage change was done to help understand the defects early in lifecycle and come up with a good solution for it. The linting was done to ensure that the codebase is consistent and maintainable and helps in improving the code quality and reducing errors.